### PR TITLE
Applying user transform before content mode in TrackConfiguration

### DIFF
--- a/Cabbage/Sources/Track/Configuration/TrackConfiguration.swift
+++ b/Cabbage/Sources/Track/Configuration/TrackConfiguration.swift
@@ -57,6 +57,15 @@ public class VideoConfiguration: NSObject, VideoConfigurationProtocol {
     
     public func applyEffect(to sourceImage: CIImage, info: VideoConfigurationEffectInfo) -> CIImage {
         var finalImage = sourceImage
+
+        if let userTransform = self.transform {
+            var transform = CGAffineTransform.identity
+            transform = transform.concatenating(CGAffineTransform(translationX: -(finalImage.extent.origin.x + finalImage.extent.width/2), y: -(finalImage.extent.origin.y + finalImage.extent.height/2)))
+            transform = transform.concatenating(userTransform)
+            transform = transform.concatenating(CGAffineTransform(translationX: (finalImage.extent.origin.x + finalImage.extent.width/2), y: (finalImage.extent.origin.y + finalImage.extent.height/2)))
+            finalImage = finalImage.transformed(by: transform)
+        }
+
         let frame = self.frame ?? CGRect(origin: CGPoint.zero, size: info.renderSize)
         switch contentMode {
         case .aspectFit:
@@ -74,15 +83,6 @@ public class VideoConfiguration: NSObject, VideoConfigurationProtocol {
             finalImage = finalImage.transformed(by: transform)
             break
         }
-        
-        if let userTransform = self.transform {
-            var transform = CGAffineTransform.identity
-            transform = transform.concatenating(CGAffineTransform(translationX: -(finalImage.extent.origin.x + finalImage.extent.width/2), y: -(finalImage.extent.origin.y + finalImage.extent.height/2)))
-            transform = transform.concatenating(userTransform)
-            transform = transform.concatenating(CGAffineTransform(translationX: (finalImage.extent.origin.x + finalImage.extent.width/2), y: (finalImage.extent.origin.y + finalImage.extent.height/2)))
-            finalImage = finalImage.transformed(by: transform)
-        }
-        
         
         finalImage = finalImage.apply(alpha: CGFloat(opacity))
         

--- a/VFCabbage.podspec
+++ b/VFCabbage.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name = 'VFCabbage'
-    s.version = '0.5'
+    s.version = '0.5.1'
     s.summary = 'A high-level video composition framework build on top of AVFoundation. It\'s simple to use and easy to extend.'
 
     s.description  = <<-DESC


### PR DESCRIPTION
**Context**:
`TrackConfiguration`'s transform property lets developers applying custom transformations on `TrackItem` while `TrackConfiguration`'s `contentMode` is responsible for how the `TrackItem`'s content is displayed on screen (`aspectFit`/`aspectFill`/`custom`).

**Issue**: 
The CGAffineTransform stored in `TrackConfiguration`'s `transform` property gets applied only after the contentMode transformations, so if a user transformation (e.g. rotation by 90 degrees) is set then .aspectFit and .aspectFill content modes won't work as expected:

https://github.com/VideoFlint/Cabbage/blob/e65b80fc04c026d14ca0a3a3ed0567d597233f86/Cabbage/Sources/Track/Configuration/TrackConfiguration.swift#L61-L84

**Proposed solution:**
Move the user transform implementation just before the contentMode transformations. 

Closes #57 