### PR TITLE
Rebuild cache flags & reused tracks

### DIFF
--- a/Cabbage/Sources/Core/CompositionGenerator.swift
+++ b/Cabbage/Sources/Core/CompositionGenerator.swift
@@ -157,8 +157,8 @@ public class CompositionGenerator {
                                         return false
                                     }
                                 }
-                                return true
                             }
+                            return true
                         }
                         return false
                     }) {

--- a/Cabbage/Sources/Core/CompositionGenerator.swift
+++ b/Cabbage/Sources/Core/CompositionGenerator.swift
@@ -188,6 +188,7 @@ public class CompositionGenerator {
             }
         }
         self.composition = composition
+        self.needRebuildComposition = false
         return composition
     }
     
@@ -242,7 +243,7 @@ public class CompositionGenerator {
         videoComposition.instructions = instructions
         videoComposition.customVideoCompositorClass = VideoCompositor.self
         self.videoComposition = videoComposition
-        
+        self.needRebuildVideoComposition = false
         return videoComposition
     }
     
@@ -303,6 +304,7 @@ public class CompositionGenerator {
         let audioMix = AVMutableAudioMix()
         audioMix.inputParameters = audioParameters
         self.audioMix = audioMix
+        self.needRebuildAudioMix = false
         return audioMix
     }
     


### PR DESCRIPTION
* fix: composition/videoComposition/audioMix cache flags
* fix: overlays' tracks can not be reused.